### PR TITLE
Multi seat support and api refactor

### DIFF
--- a/examples/clipboard.rs
+++ b/examples/clipboard.rs
@@ -6,7 +6,7 @@ use sctk::utils::{DoubleMemPool, MemPool};
 use sctk::window::{ConceptFrame, Event as WEvent, Window};
 use sctk::Environment;
 
-use sctk::reexports::client::protocol::{wl_shm, wl_surface};
+use sctk::reexports::client::protocol::{wl_seat, wl_shm, wl_surface};
 use sctk::reexports::client::{Display, NewProxy};
 
 use andrew::shapes::rectangle;
@@ -18,14 +18,23 @@ fn main() {
         Display::connect_to_env().expect("Failed to connect to the wayland server.");
     let env = Environment::from_display(&*display, &mut event_queue).unwrap();
 
-    let mut clipboard = smithay_clipboard::WaylandClipboard::new_threaded(
-        display.get_display_ptr() as *mut std::ffi::c_void,
-    );
+    let mut clipboard = smithay_clipboard::WaylandClipboard::new_threaded(&display);
     let cb_contents = Arc::new(Mutex::new(String::new()));
 
+    let seat_name = Arc::new(Mutex::new(String::new()));
+    let seat_name_clone = seat_name.clone();
     let seat = env
         .manager
-        .instantiate_range(1, 6, NewProxy::implement_dummy)
+        .instantiate_range(2, 6, move |proxy| {
+            proxy.implement_closure(
+                move |event, _| {
+                    if let wl_seat::Event::Name { name } = event {
+                        *seat_name_clone.lock().unwrap() = name
+                    }
+                },
+                (),
+            )
+        })
         .unwrap();
 
     let need_redraw = Arc::new(atomic::AtomicBool::new(false));
@@ -39,11 +48,15 @@ fn main() {
         } = event
         {
             if text == " " {
-                *cb_contents_clone.lock().unwrap() = dbg!(clipboard.load());
+                *cb_contents_clone.lock().unwrap() =
+                    dbg!(clipboard.load(seat_name.lock().unwrap().clone()));
                 need_redraw_clone.store(true, atomic::Ordering::Relaxed)
             } else if text == "s" {
-                clipboard
-                    .store("This is an example text thats been copied to the wayland clipboard :)");
+                clipboard.store(
+                    seat_name.lock().unwrap().clone(),
+                    "This is an example text thats been copied to the wayland clipboard :)"
+                        .to_string(),
+                );
             }
         }
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,10 +59,10 @@ impl WaylandClipboard {
     pub fn new_threaded(display: &Display) -> Self {
         let (request_send, request_recv) = mpsc::channel::<WaylandRequest>();
         let (load_send, load_recv) = mpsc::channel();
-        let display = unsafe { display.get_display_ptr().as_mut().unwrap() };
+        let display = display.clone();
 
         std::thread::spawn(move || {
-            let (display, mut event_queue) = unsafe { Display::from_external_display(display) };
+            let mut event_queue = display.create_event_queue();
             Self::clipboard_thread(&display, &mut event_queue, request_recv, load_send);
         });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,8 +248,8 @@ impl WaylandClipboard {
 
     /// Returns text from the wayland clipboard
     ///
-    /// Only works when the window connected to the WlDisplay has
-    /// keyboard focus
+    /// Must be provided with a seat name and that seat must be in
+    /// focus to work
     pub fn load<S: Into<String>>(&mut self, seat_name: S) -> String {
         self.request_send
             .send(WaylandRequest::Load(seat_name.into()))
@@ -259,8 +259,8 @@ impl WaylandClipboard {
 
     /// Stores text in the wayland clipboard
     ///
-    /// Only works when the window connected to the WlDisplay has
-    /// keyboard focus
+    /// Must be provided with a seat name and that seat must be in
+    /// focus to work
     pub fn store<S: Into<String>>(&mut self, seat_name: S, text: S) {
         self.request_send
             .send(WaylandRequest::Store(seat_name.into(), text.into()))


### PR DESCRIPTION
Fixes https://github.com/Smithay/smithay-clipboard/issues/1

Makes the main two creation functions `new_threaded()` that creates a `WaylandClipboard` from a `&Display` and `new_threaded_from_external()` that creates it from `*mut wl_display`.

`store()` and `load()` functions will now take a `seat_name: String` argument to select the wayland seat to use for the clipboard. The tracking of these seats will happen automatically, internally.
 
This is still waiting on `Display` to implement the `Clone` trait.