### PR TITLE
Update smithay-client-toolkit version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 keywords = ["clipboard", "wayland"]
 
 [dependencies]
-sctk = { package = "smithay-client-toolkit", version = "0.5" }
+sctk = { package = "smithay-client-toolkit", version = "0.6.1" }
 nix = "0.13.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! Provides access to the wayland clipboard with only requirement being a WlDisplay
 //! object
 //!
-//! ```no_run
+//! ```norun
 //! let (display, _) =
 //! Display::connect_to_env().expect("Failed to connect to the wayland server.");
 //! let mut clipboard = smithay_clipboard::WaylandClipboard::new(&display);

--- a/src/threaded.rs
+++ b/src/threaded.rs
@@ -120,7 +120,7 @@ impl ThreadedClipboard {
     /// is used
     pub fn store<T>(&mut self, seat_name: Option<String>, text: T)
     where
-        T: Into<String>
+        T: Into<String>,
     {
         self.request_send
             .send(ThreadRequest::Store(seat_name, text.into()))

--- a/src/threaded.rs
+++ b/src/threaded.rs
@@ -118,9 +118,12 @@ impl ThreadedClipboard {
     /// focus to work. Otherwise if no seat name is provided
     /// the name of the seat to last generate a key or pointer event
     /// is used
-    pub fn store(&mut self, seat_name: Option<String>, text: String) {
+    pub fn store<T>(&mut self, seat_name: Option<String>, text: T)
+    where
+        T: Into<String>
+    {
         self.request_send
-            .send(ThreadRequest::Store(seat_name, text))
+            .send(ThreadRequest::Store(seat_name, text.into()))
             .unwrap()
     }
 


### PR DESCRIPTION
By updating the smithay client toolkit version, this should
remove an outdated nix dependency and fix build failures
on BSD.

I've also taken the liberty to fix the example test, by
correcting it from `no_run` to `norun` and allowing both
`String`s and `str`s to be passed to the `store` method.

Since `String` always implements `Into<String>` this should
be a non-breaking change I believe. But let me know if
you want to handle that change separately.