### PR TITLE
Update to nix 0.14.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["clipboard", "wayland"]
 
 [dependencies]
 sctk = { package = "smithay-client-toolkit", version = "0.6.1" }
-nix = "0.13.0"
+nix = "0.14.1"
 
 [dev-dependencies]
 andrew = "0.2"


### PR DESCRIPTION
This should probably be handled as a follow-up to https://github.com/Smithay/wayland-rs/pull/265

Once that is merged, I can update this to completely get rid of nix 0.13.