### PR TITLE
Normalize loaded content for text/plain;charset=utf-8 mime type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Perform loaded data normalization for text/plain;charset=utf-8 mime type
+
 ## 0.3.5 -- 2019-09-3
 
 - Fix primary selection storing, when releasing button outside of the surface

--- a/src/threaded.rs
+++ b/src/threaded.rs
@@ -309,6 +309,9 @@ fn clipboard_thread(
                                 contents
                             })
                         });
+                    // Normalization should happen only on `text/plain;charset=utf-8`, in case we
+                    // add other mime types consult gtk for normalization.
+                    let contents = normilize_to_lf(contents);
                     load_send.send(contents).unwrap();
                 }
                 // Store text in the clipboard
@@ -400,6 +403,9 @@ fn clipboard_thread(
                     } else {
                         String::new()
                     };
+                    // Normalization should happen only on `text/plain;charset=utf-8`, in case we
+                    // add other mime types consult gtk for normalization.
+                    let contents = normilize_to_lf(contents);
                     load_send.send(contents).unwrap();
                 }
                 // Store text in the primary clipboard
@@ -718,4 +724,13 @@ fn implement_seat(
         )
     })
     .unwrap();
+}
+
+// Normalize \r and \r\n into \n.
+//
+// Gtk does this for text/plain;charset=utf-8, so following them here, otherwise there is
+// a chance of getting extra new lines on load, since they're converting \r and \n into
+// \r\n on every store.
+fn normilize_to_lf(text: String) -> String {
+    text.replace("\r\n", "\n").replace("\r", "\n")
 }


### PR DESCRIPTION
Some frameworks(gtk) normalize \r and \n into \r\n for text/plain;charset=utf-8,
so when we're loading clipboard content we should normalize \r\n and \r into \n
according to gtk loading normalization code. We can avoid this
normalization on store, since \n is a native terminator for a platform
and its expected to work.

Relevant gtk code
https://gitlab.gnome.org/GNOME/gtk/blob/master/gtk/gtkselection.c#L547
https://gitlab.gnome.org/GNOME/gtk/blob/master/gtk/gtkselection.c#L588