### PR TITLE
Remove artificial sleep for 50ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Perform loaded data normalization for text/plain;charset=utf-8 mime type
+- Fix clipboard throttling
 
 ## 0.3.5 -- 2019-09-3
 

--- a/src/threaded.rs
+++ b/src/threaded.rs
@@ -284,7 +284,6 @@ fn clipboard_thread(
     // Thread loop to handle requests and dispatch the event queue
     loop {
         if let Ok(request) = request_recv.try_recv() {
-
             // Lower sleep amount to zero, so the next recv will be instant
             sleep_amount = 0;
 
@@ -508,10 +507,9 @@ fn clipboard_thread(
                 }
             } else if sleep_amount < 50 {
                 // The aim of this different sleep times is to provide a good performance under
-                // highload and not waste system resources too much when idle
+                // high load and not waste system resources too much when idle
                 sleep_amount = std::cmp::min(2 * sleep_amount, 50);
             }
-
         } else if sleep_amount == 0 {
             // Reset sleep amount from zero back to one, so sleep sequence could reach 50
             sleep_amount = 1;

--- a/src/threaded.rs
+++ b/src/threaded.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 use std::os::unix::io::FromRawFd;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
-use std::thread::sleep;
+use std::thread;
 use std::time::Duration;
 
 use nix::fcntl::OFlag;
@@ -275,9 +275,19 @@ fn clipboard_thread(
     });
     event_queue.sync_roundtrip().unwrap();
 
+    // We should provide lower sleep amounts in a moments of spaming our clipboard
+    let mut sleep_amount = 50;
+    // Provide our clipboard a warm start, so 16 initial cycles will be at 1ms and other will go
+    // like 1 2 4 8 16 32 50 50 and so on
+    let mut warm_start_amount = 0;
+
     // Thread loop to handle requests and dispatch the event queue
     loop {
         if let Ok(request) = request_recv.try_recv() {
+
+            // Lower sleep amount to zero, so the next recv will be instant
+            sleep_amount = 0;
+
             match request {
                 // Load text from clipboard
                 ThreadRequest::Load(seat_name) => {
@@ -480,9 +490,34 @@ fn clipboard_thread(
                 ThreadRequest::Kill => break,
             }
         }
-        // Dispatch the event queue and block for 50 milliseconds
-        event_queue.dispatch_pending().unwrap();
-        sleep(Duration::from_millis(50));
+        // Dispatch the event queue and block for `sleep_amount`
+        let pending_events = event_queue.dispatch_pending().unwrap();
+        let num_seats = seat_map.lock().unwrap().len();
+
+        // If some app is trying to spam us when there no seats, it's likely that someone is
+        // trying to paste from us
+        if num_seats == 0 && pending_events != 0 {
+            sleep_amount = 0;
+        } else if sleep_amount > 0 {
+            thread::sleep(Duration::from_millis(sleep_amount));
+
+            if warm_start_amount < 16 {
+                warm_start_amount += 1;
+                if warm_start_amount == 16 {
+                    sleep_amount = 1;
+                }
+            } else if sleep_amount < 50 {
+                // The aim of this different sleep times is to provide a good performance under
+                // highload and not waste system resources too much when idle
+                sleep_amount = std::cmp::min(2 * sleep_amount, 50);
+            }
+
+        } else if sleep_amount == 0 {
+            // Reset sleep amount from zero back to one, so sleep sequence could reach 50
+            sleep_amount = 1;
+            // Reset warm start to accelerate the initial clipboard requests
+            warm_start_amount = 0;
+        }
     }
 }
 


### PR DESCRIPTION
This sleep throttles our clipboard by a lot. In it's current state there's a huge chance to block the entire app if the user has a high key repeat rate and app requests the clipboard in a singe threaded way (like `alacritty`).

While moving a clipboard to it's own thread is a good solution for `alacritty` there is still a problem with a clipboard throughput, by this I mean that it can keeps pasting even if a user released a key a while ago. The possible solution to the mentioned problem would be to drop clipboard requests in a user's app, however the speed of pasting will still be not satisfying compared to GTK apps.

This leads us to removing this artificial sleep and changing `try_recv` to just `recv`. This approach performs very good and can keep up with high repeat rate(60) and not to hand single threaded app like alacritty. Moreover it can keep up even wtih repeat_rate 255 in sway if you run alacritty's clipboard on a different thread and honor everything like an e.g. . I've also tested in GNOME on Wayland and it was fine.

cc @trimental 