### PR TITLE
Avoid panic on dispatch failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed clipboard crashing, when seat has neither keyboard nor pointer focus
 - Advertise UTF8_STRING mimetype
+- Fixed crash when writing data to the server fails
 
 ## 0.5.1 -- 2020-07-10
 


### PR DESCRIPTION
Prevent crash when calling unwrap on either sync_roundtrip
or dispatch_pending, and handle such case by replying downstream
that clipboard is dead.