### PR TITLE
Mark 'Clipboard::new' as 'unsafe'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Updated smithay-client-toolkit to 0.12
+- **Breaking** `Clipboard::new` is now marked with `unsafe`
 
 ## 0.5.2 -- 2020-08-30
 

--- a/examples/clipboard.rs
+++ b/examples/clipboard.rs
@@ -172,7 +172,7 @@ fn main() {
 
     sctk::WaylandSource::new(queue).quick_insert(event_loop.handle()).unwrap();
 
-    let clipboard = Clipboard::new(display.get_display_ptr() as *mut _);
+    let clipboard = unsafe { Clipboard::new(display.get_display_ptr() as *mut _) };
     let mut dispatch_data = DispatchData::new(clipboard);
 
     loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides access to the Wayland clipboard for gui applications. The user should have surface
 //! around.
 
+#![deny(clippy::all, clippy::if_not_else, clippy::enum_glob_use, clippy::wrong_pub_self_convention)]
 use std::ffi::c_void;
 use std::io::Result;
 use std::sync::mpsc::{self, Receiver, Sender};
@@ -29,7 +30,7 @@ impl Clipboard {
     /// `display` must be a valid `*mut wl_display` pointer, and it must remain
     /// valid for as long as `Clipboard` object is alive.
     pub unsafe fn new(display: *mut c_void) -> Self {
-        let display = unsafe { Display::from_external_display(display as *mut _) };
+        let display = Display::from_external_display(display as *mut _);
 
         // Create channel to send data to clipboard thread.
         let (request_sender, clipboard_request_receiver) = mpsc::channel();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub struct Clipboard {
 impl Clipboard {
     /// Creates new clipboard which will be running on its own thread with its own event queue to
     /// handle clipboard requests.
-    pub fn new(display: *mut c_void) -> Self {
+    pub unsafe fn new(display: *mut c_void) -> Self {
         let display = unsafe { Display::from_external_display(display as *mut _) };
 
         // Create channel to send data to clipboard thread.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,11 @@ pub struct Clipboard {
 impl Clipboard {
     /// Creates new clipboard which will be running on its own thread with its own event queue to
     /// handle clipboard requests.
+    ///
+    /// # Safety
+    ///
+    /// `display` must be a valid `*mut wl_display` pointer, and it must remain
+    /// valid for as long as `Clipboard` object is alive.
     pub unsafe fn new(display: *mut c_void) -> Self {
         let display = unsafe { Display::from_external_display(display as *mut _) };
 

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -211,11 +211,11 @@ fn worker_impl(display: Display, request_rx: Receiver<Command>, reply_tx: Sender
             // Reset the time we're sleeping.
             sa_tracker.reset_sleep();
 
-            if queue.sync_roundtrip(&mut dispatch_data, |_, _, _| unimplemented!()).is_err() {
-                if request == Command::LoadPrimary || request == Command::Load {
-                    handlers::reply_error(&reply_tx, "primary clipboard is not available.");
-                    break;
-                }
+            if queue.sync_roundtrip(&mut dispatch_data, |_, _, _| unimplemented!()).is_err()
+                && (request == Command::LoadPrimary || request == Command::Load)
+            {
+                handlers::reply_error(&reply_tx, "primary clipboard is not available.");
+                break;
             }
 
             // Get latest observed seat and serial.


### PR DESCRIPTION
Since this call takes raw pointer it's generally unsafe.