### PR TITLE
Fix segfault in multithreaded context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Segfault when dropping clipboard in multithreaded context while main queue is still running
+
 ## 0.6.1 -- 2020-10-13
 
 - Crash when failing to write to a clipboard

--- a/examples/clipboard.rs
+++ b/examples/clipboard.rs
@@ -223,7 +223,7 @@ fn process_keyboard_event(event: KeyboardEvent, dispatch_data: &mut DispatchData
             let contents = dispatch_data
                 .clipboard
                 .load()
-                .unwrap_or_else(|_| String::from("Failed to load primary selection"));
+                .unwrap_or_else(|_| String::from("Failed to load selection"));
             println!("Paste: {}", contents);
         }
         // Copy primary.

--- a/src/worker/dispatch_data.rs
+++ b/src/worker/dispatch_data.rs
@@ -1,47 +1,68 @@
+use std::collections::VecDeque;
+use std::slice::IterMut;
+
 use sctk::reexports::client::protocol::wl_seat::WlSeat;
 
+use super::seat_data::SeatData;
+
 /// Data to track latest seat and serial for clipboard requests.
-#[derive(Default)]
 pub struct ClipboardDispatchData {
-    observed_seats: Vec<(WlSeat, u32)>,
-    last_pos: usize,
+    /// Seats that our application encountered. The first seat is the latest one we've encountered.
+    observed_seats: VecDeque<(WlSeat, u32)>,
+
+    /// All the seats that were advertised.
+    seats: Vec<SeatData>,
 }
 
 impl ClipboardDispatchData {
     /// Builds new `ClipboardDispatchData` with all fields equal to `None`.
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(seats: Vec<SeatData>) -> Self {
+        Self { observed_seats: Default::default(), seats }
+    }
+
+    /// Returns the requested seat's data or adds a new one.
+    pub fn get_seat_data_or_add(&mut self, seat: WlSeat) -> &mut SeatData {
+        let pos = self.seats.iter().position(|st| st.seat == seat);
+        let index = pos.unwrap_or_else(|| {
+            self.seats.push(SeatData::new(seat, None, None));
+            self.seats.len() - 1
+        });
+
+        &mut self.seats[index]
+    }
+
+    pub fn seats(&mut self) -> IterMut<'_, SeatData> {
+        self.seats.iter_mut()
     }
 
     /// Set the last observed seat.
-    pub fn set_last_seat(&mut self, seat: WlSeat, serial: u32) {
+    pub fn set_last_observed_seat(&mut self, seat: WlSeat, serial: u32) {
         let pos = self.observed_seats.iter().position(|st| st.0 == seat);
-        match pos {
+        let (seat, serial) = match pos {
             Some(pos) => {
-                // Update serial and set the last data we've seen.
-                self.observed_seats[pos].1 = serial;
-                self.last_pos = pos;
+                // We just found that `pos` we're going to remove, so unwrapping is safe.
+                self.observed_seats.remove(pos).unwrap()
             }
-            None => {
-                // Add new seat and mark it as last.
-                self.last_pos = self.observed_seats.len();
-                self.observed_seats.push((seat, serial));
-            }
-        }
+            None => (seat, serial),
+        };
+
+        // Add seat to front, thus it'll be the latest observed one.
+        self.observed_seats.push_front((seat, serial));
     }
 
-    /// Remove the given seat from the observer seats.
-    pub fn remove_seat(&mut self, seat: WlSeat) {
-        let pos = self.observed_seats.iter().position(|st| st.0 == seat);
+    /// Remove the given seat from the observed seats.
+    pub fn remove_observed_seat(&mut self, seat: WlSeat) {
+        let pos = match self.observed_seats.iter().position(|st| st.0 == seat) {
+            Some(pos) => pos,
+            None => return,
+        };
 
-        if let Some(pos) = pos {
-            // Remove the seat data.
-            self.observed_seats.remove(pos);
-        }
+        // Remove the seat data.
+        self.observed_seats.remove(pos);
     }
 
     /// Return the last observed seat and the serial.
-    pub fn last_seat(&self) -> Option<&(WlSeat, u32)> {
-        self.observed_seats.get(self.last_pos)
+    pub fn last_observed_seat(&self) -> Option<&(WlSeat, u32)> {
+        self.observed_seats.front()
     }
 }

--- a/src/worker/handlers.rs
+++ b/src/worker/handlers.rs
@@ -104,10 +104,10 @@ pub fn pointer_handler(seat: WlSeat, event: PointerEvent, mut dispatch_data: Dis
     };
     match event {
         PointerEvent::Enter { serial, .. } => {
-            dispatch_data.set_last_seat(seat, serial);
+            dispatch_data.set_last_observed_seat(seat, serial);
         }
         PointerEvent::Button { serial, .. } => {
-            dispatch_data.set_last_seat(seat, serial);
+            dispatch_data.set_last_observed_seat(seat, serial);
         }
         _ => {}
     }
@@ -121,13 +121,13 @@ pub fn keyboard_handler(seat: WlSeat, event: KeyboardEvent, mut dispatch_data: D
     };
     match event {
         KeyboardEvent::Enter { serial, .. } => {
-            dispatch_data.set_last_seat(seat, serial);
+            dispatch_data.set_last_observed_seat(seat, serial);
         }
         KeyboardEvent::Key { serial, .. } => {
-            dispatch_data.set_last_seat(seat, serial);
+            dispatch_data.set_last_observed_seat(seat, serial);
         }
         KeyboardEvent::Leave { .. } => {
-            dispatch_data.remove_seat(seat);
+            dispatch_data.remove_observed_seat(seat);
         }
         KeyboardEvent::Keymap { fd, .. } => {
             // Prevent fd leaking.


### PR DESCRIPTION
Dropping libwayland-client's queue in multithreaded context is safe if
and only if there're no alive proxies on it, otherwise it could result
in use-after-free. For more see [1] and [2].

[1] - https://gitlab.freedesktop.org/wayland/wayland/-/issues/13
[2] - https://github.com/Smithay/wayland-rs/issues/359