### PR TITLE
Fix serial ID tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Consecutive clipboard stores dropped until the application is refocused
+
 ## 0.6.2 -- 2020-12-17
 
 - Segfault when dropping clipboard in multithreaded context while main queue is still running

--- a/src/worker/dispatch_data.rs
+++ b/src/worker/dispatch_data.rs
@@ -37,28 +37,18 @@ impl ClipboardDispatchData {
 
     /// Set the last observed seat.
     pub fn set_last_observed_seat(&mut self, seat: WlSeat, serial: u32) {
-        let pos = self.observed_seats.iter().position(|st| st.0 == seat);
-        let (seat, serial) = match pos {
-            Some(pos) => {
-                // We just found that `pos` we're going to remove, so unwrapping is safe.
-                self.observed_seats.remove(pos).unwrap()
-            }
-            None => (seat, serial),
-        };
+        // Assure each seat exists only once.
+        self.remove_observed_seat(&seat);
 
-        // Add seat to front, thus it'll be the latest observed one.
+        // Add the seat to front, making it the latest observed one.
         self.observed_seats.push_front((seat, serial));
     }
 
     /// Remove the given seat from the observed seats.
-    pub fn remove_observed_seat(&mut self, seat: WlSeat) {
-        let pos = match self.observed_seats.iter().position(|st| st.0 == seat) {
-            Some(pos) => pos,
-            None => return,
-        };
-
-        // Remove the seat data.
-        self.observed_seats.remove(pos);
+    pub fn remove_observed_seat(&mut self, seat: &WlSeat) {
+        if let Some(pos) = self.observed_seats.iter().position(|st| &st.0 == seat) {
+            self.observed_seats.remove(pos);
+        }
     }
 
     /// Return the last observed seat and the serial.

--- a/src/worker/handlers.rs
+++ b/src/worker/handlers.rs
@@ -127,7 +127,7 @@ pub fn keyboard_handler(seat: WlSeat, event: KeyboardEvent, mut dispatch_data: D
             dispatch_data.set_last_observed_seat(seat, serial);
         }
         KeyboardEvent::Leave { .. } => {
-            dispatch_data.remove_observed_seat(seat);
+            dispatch_data.remove_observed_seat(&seat);
         }
         KeyboardEvent::Keymap { fd, .. } => {
             // Prevent fd leaking.

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -224,7 +224,6 @@ fn worker_impl(display: Display, request_rx: Receiver<Command>, reply_tx: Sender
                     continue;
                 }
             };
-
             let serial = *serial;
 
             // Handle requests.


### PR DESCRIPTION
The serial ID tracking was incorrectly reinserting any previously used
seats without updating the serial information, leading to consecutive
clipboard stores being dropped by the compositor.

Fixes #33.