### PR TITLE
Fix typo in normalize_to_lf function name

### DIFF
--- a/src/mime.rs
+++ b/src/mime.rs
@@ -44,6 +44,6 @@ impl ToString for MimeType {
 /// 'text' mime types require CRLF line ending according to
 /// RFC-2046, however the platform line terminator and what applications
 /// expect is LF.
-pub fn normilize_to_lf(text: String) -> String {
+pub fn normalize_to_lf(text: String) -> String {
     text.replace("\r\n", "\n").replace("\r", "\n")
 }

--- a/src/worker/handlers.rs
+++ b/src/worker/handlers.rs
@@ -51,7 +51,7 @@ macro_rules! handle_load {
             let mut contents = String::new();
             let result = reader.read_to_string(&mut contents).map(|_| {
                 if mime_type == MimeType::Utf8String {
-                    mime::normilize_to_lf(contents)
+                    mime::normalize_to_lf(contents)
                 } else {
                     contents
                 }


### PR DESCRIPTION
It took me a bit to figure out why I couldn't find this function when
searching for it in the repository. Turns out this time it wasn't me
spelled it wrong.