### PR TITLE
Add dlopen feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,11 @@ keywords = ["clipboard", "wayland"]
 
 [dependencies]
 sctk = { package = "smithay-client-toolkit", version = "0.14", default-features = false }
-wayland-client = { version = "0.28", features = ["dlopen"] }
+wayland-client = { version = "0.28", features = ["use_system_lib"] }
 
 [dev-dependencies]
-sctk = { package = "smithay-client-toolkit", version = "0.14"}
+sctk = { package = "smithay-client-toolkit", version = "0.14", default-features = false, features = ["calloop"] }
+
+[features]
+default = ["dlopen"]
+dlopen = ["sctk/dlopen", "wayland-client/dlopen"]


### PR DESCRIPTION
If the dlopen feature is disabled, system libraries depended on by wayland-client and smithay-client-toolkit will be statically linked instead of trying to dlopen them at runtime, which is important if they're in weird locations off the system search path at runtime but not at build time.