### PR TITLE
Bump smithay-client-toolkit to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ license = "MIT"
 keywords = ["clipboard", "wayland"]
 
 [dependencies]
-sctk = { package = "smithay-client-toolkit", version = "0.12", default-features = false }
+sctk = { package = "smithay-client-toolkit", version = "0.14", default-features = false }
 wayland-client = { version = "0.28", features = ["dlopen"] }
 
 [dev-dependencies]
-sctk = { package = "smithay-client-toolkit", version = "0.12"}
+sctk = { package = "smithay-client-toolkit", version = "0.14"}

--- a/examples/clipboard.rs
+++ b/examples/clipboard.rs
@@ -3,11 +3,8 @@ use std::io::{BufWriter, Seek, SeekFrom, Write};
 use sctk::seat;
 use sctk::seat::keyboard::{self, Event as KeyboardEvent, KeyState, RepeatKind};
 use sctk::shm::MemPool;
-use sctk::window::{ConceptFrame, Event as WindowEvent};
+use sctk::window::{Event as WindowEvent, FallbackFrame};
 
-use sctk::reexports::calloop::Source as EventLoopSource;
-use sctk::reexports::client::protocol::wl_keyboard::WlKeyboard;
-use sctk::reexports::client::protocol::wl_seat::WlSeat;
 use sctk::reexports::client::protocol::wl_shm;
 use sctk::reexports::client::protocol::wl_surface::WlSurface;
 
@@ -35,7 +32,7 @@ fn main() {
         .expect("unable to connect to a Wayland compositor.");
 
     // Create event loop
-    let mut event_loop = sctk::reexports::calloop::EventLoop::<DispatchData>::new().unwrap();
+    let mut event_loop = sctk::reexports::calloop::EventLoop::<DispatchData>::try_new().unwrap();
 
     // Initial window dimentions
     let mut dimentions = (320u32, 240u32);
@@ -45,7 +42,7 @@ fn main() {
 
     // Create window
     let mut window = env
-        .create_window::<ConceptFrame, _>(
+        .create_window::<FallbackFrame, _>(
             surface,
             None,
             dimentions,
@@ -77,7 +74,7 @@ fn main() {
     let mut pools = env.create_double_pool(|_| {}).expect("failed to create a memory pool.");
 
     // Structure to track seats
-    let mut seats = Vec::<(WlSeat, Option<(WlKeyboard, EventLoopSource<_>)>)>::new();
+    let mut seats = Vec::new();
 
     // Process existing seats
     for seat in env.get_all_seats() {

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,3 +1,4 @@
+use sctk::MissingGlobal;
 use sctk::data_device::{DataDevice, DataDeviceHandler, DataDeviceHandling, DndEvent};
 use sctk::primary_selection::{
     PrimarySelectionDevice, PrimarySelectionDeviceManager, PrimarySelectionHandler,
@@ -39,7 +40,7 @@ impl PrimarySelectionHandling for SmithayClipboard {
         &self,
         seat: &WlSeat,
         f: F,
-    ) -> Result<(), ()> {
+    ) -> Result<(), MissingGlobal> {
         self.primary_selection_manager.with_primary_selection(seat, f)
     }
 
@@ -49,14 +50,14 @@ impl PrimarySelectionHandling for SmithayClipboard {
 }
 
 impl DataDeviceHandling for SmithayClipboard {
-    fn set_callback<F>(&mut self, callback: F) -> Result<(), ()>
+    fn set_callback<F>(&mut self, callback: F) -> Result<(), MissingGlobal>
     where
         F: FnMut(WlSeat, DndEvent, DispatchData) + 'static,
     {
         self.data_device_manager.set_callback(callback)
     }
 
-    fn with_device<F: FnOnce(&DataDevice)>(&self, seat: &WlSeat, f: F) -> Result<(), ()> {
+    fn with_device<F: FnOnce(&DataDevice)>(&self, seat: &WlSeat, f: F) -> Result<(), MissingGlobal> {
         self.data_device_manager.with_device(seat, f)
     }
 }


### PR DESCRIPTION
Hi! Bumping to the latest smithay-client-toolkit removes a dependency on `andrew` which is also depends on `rusttype`, which isn't maintained anymore. API changes were trivial in the src directory, I'm a bit less certain about the tests, though. This removes ~100 lines to the `Cargo.lock` file, which must remove a certain number of dependencies.