### PR TITLE
Make copy work on arbitrarily long strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["clipboard", "wayland"]
 [dependencies]
 sctk = { package = "smithay-client-toolkit", version = "0.16", default-features = false }
 wayland-client = { version = "0.29", features = ["use_system_lib"] }
+libc = "0.2"
 
 [dev-dependencies]
 sctk = { package = "smithay-client-toolkit", version = "0.16", default-features = false, features = ["calloop"] }


### PR DESCRIPTION
I noticed that there was a limit on the amount of data that could be pushed into the clipboard  - for me it was 65536 bytes. I determined that this limit was a linux internal buffer size - what's happening is that the socket that gets provided to transfer the data over is nonblocking, but the code in this crate which handles the transfer assumes it's blocking, so the write only fills up the operating system's buffer before returning.

It's not enough to just loop until all the data goes over the socket, since if you're trying to copy-paste from an application to itself, this will result in a deadlock. I observed some other applications tossing the data socket into a pool which is polled along with the main wayland socket to determine which when data can be written or when additional wayland events become available, but I think this would require integration with an event loop. In lieu of that, this patch starts a new thread for each piece of data being copied and sends it sockets to copy the data onto. I verified empirically that when the copied data is released (i.e. something else is copied) the thread exits.