### PR TITLE
Allow text/plain text type without charset parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Allow text/plain text type without charset parameter
+
 ## 0.6.6 -- 2022-06-20
 
 - Update SCTK to 0.16

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -1,5 +1,5 @@
 /// List of allowed mimes.
-static ALLOWED_MIME_TYPES: [&str; 2] = ["text/plain;charset=utf-8", "UTF8_STRING"];
+static ALLOWED_MIME_TYPES: [&str; 3] = ["text/plain;charset=utf-8", "text/plain", "UTF8_STRING"];
 
 /// Mime type supported by clipboard.
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
@@ -8,11 +8,15 @@ pub enum MimeType {
     ///
     /// The primary mime type used by most clients
     TextPlainUtf8 = 0,
+    /// text/plain mime type.
+    ///
+    /// Fallback without charset parameter
+    TextPlain = 1,
     /// UTF8_STRING mime type.
     ///
     /// Some X11 clients are using only this mime type, so we
     /// should have it as a fallback just in case.
-    Utf8String = 1,
+    Utf8String = 2,
 }
 
 impl MimeType {
@@ -24,6 +28,8 @@ impl MimeType {
         for offered_mime_type in offered_mime_types.iter() {
             if offered_mime_type == ALLOWED_MIME_TYPES[Self::TextPlainUtf8 as usize] {
                 return Some(Self::TextPlainUtf8);
+            } else if offered_mime_type == ALLOWED_MIME_TYPES[Self::TextPlain as usize] {
+                return Some(Self::TextPlain);
             } else if offered_mime_type == ALLOWED_MIME_TYPES[Self::Utf8String as usize] {
                 return Some(Self::Utf8String);
             }

--- a/src/worker/handlers.rs
+++ b/src/worker/handlers.rs
@@ -73,7 +73,11 @@ macro_rules! handle_store {
      $sel_source:ident, $sel_device:ident, $event_ty:ident,
      $seat:ident, $serial:ident, $queue:ident, $contents:ident) => {
         let data_source = $env.$sel_source(
-            vec![MimeType::TextPlainUtf8.to_string(), MimeType::Utf8String.to_string()],
+            vec![
+                MimeType::TextPlainUtf8.to_string(),
+                MimeType::TextPlain.to_string(),
+                MimeType::Utf8String.to_string(),
+            ],
             move |event, _| {
                 if let $event_ty::Send { mut pipe, .. } = event {
                     // If we fail to write here, it means that other side closed the pipe, thus


### PR DESCRIPTION
bemenu cannot paste after copying from a smithay-clipboard application, because bemenu calls `wl-paste -t text/plain` and that rejects `text/plain;charset=utf-8`. For this specific problem, it could be argued that bemenu should add the charset parameter or that type matching inside wl-paste should be relaxed. However, many other applications (Qt, GTK, Chromium, Firefox) offer `text/plain` also encoded as utf-8 as a fallback to `text/plain;charset=utf-8`, so this PR does the same for smithay-clipboard.