### PR TITLE
Fix panic when wayland display connection breaks

### DIFF
--- a/examples/clipboard.rs
+++ b/examples/clipboard.rs
@@ -2,8 +2,6 @@
 // application. For more details on what is going on, consult the
 // `smithay-client-toolkit` examples.
 
-use std::convert::TryInto;
-
 use sctk::compositor::{CompositorHandler, CompositorState};
 use sctk::output::{OutputHandler, OutputState};
 use sctk::reexports::calloop::{EventLoop, LoopHandle};
@@ -23,7 +21,7 @@ use sctk::{
     delegate_compositor, delegate_keyboard, delegate_output, delegate_registry, delegate_seat,
     delegate_shm, delegate_xdg_shell, delegate_xdg_window, registry_handlers,
 };
-use smithay_clipboard::{self, Clipboard};
+use smithay_clipboard::Clipboard;
 
 const MIN_DIM_SIZE: usize = 256;
 

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -42,9 +42,9 @@ impl MimeType {
     }
 }
 
-impl ToString for MimeType {
-    fn to_string(&self) -> String {
-        String::from(ALLOWED_MIME_TYPES[*self as usize])
+impl std::fmt::Display for MimeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", ALLOWED_MIME_TYPES[*self as usize])
     }
 }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -95,9 +95,7 @@ fn worker_impl(
     WaylandSource::new(connection, event_queue).insert(loop_handle).unwrap();
 
     loop {
-        event_loop.dispatch(None, &mut state).unwrap();
-
-        if state.exit {
+        if event_loop.dispatch(None, &mut state).is_err() || state.exit {
             break;
         }
     }


### PR DESCRIPTION
Instead, terminate the thread and consider the clipboard dead. The application can now gracefully deal with the situation.

Closes #52