### PR TITLE
feat: support custom mime types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.8.0
+
+- Add support for loading and storing custom data.
+- **Breaking** `Clipboard::load` renamed to `Clipboard::load_text`.
+- **Breaking** `Clipboard::load_primary` renamed to `Clipboard::load_primary_text`.
+- **Breaking** `Clipboard::store` renamed to `Clipboard::store_text`.
+- **Breaking** `Clipboard::store_primary` renamed to `Clipboard::store_primary_text`.
+
 ## 0.7.1
 
 - Don't panic on display disconnect

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,12 @@ rust-version = "1.65.0"
 libc = "0.2.149"
 sctk = { package = "smithay-client-toolkit", version = "0.18.0", default-features = false, features = ["calloop"] }
 wayland-backend = { version = "0.3.0", default_features = false, features = ["client_system"] }
+thiserror = "1.0.57"
 
 [dev-dependencies]
 sctk = { package = "smithay-client-toolkit", version = "0.18.0", default-features = false, features = ["calloop", "xkbcommon"] }
+url = "2.5.0"
+dirs = "5.0.1"
 
 [features]
 default = ["dlopen"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ rust-version = "1.65.0"
 libc = "0.2.149"
 sctk = { package = "smithay-client-toolkit", version = "0.18.0", default-features = false, features = ["calloop"] }
 wayland-backend = { version = "0.3.0", default_features = false, features = ["client_system"] }
-thiserror = "1.0.57"
 
 [dev-dependencies]
-sctk = { package = "smithay-client-toolkit", version = "0.18.0", default-features = false, features = ["calloop", "xkbcommon"] }
-url = "2.5.0"
 dirs = "5.0.1"
+sctk = { package = "smithay-client-toolkit", version = "0.18.0", default-features = false, features = ["calloop", "xkbcommon"] }
+thiserror = "1.0.57"
+url = "2.5.0"
 
 [features]
 default = ["dlopen"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,6 @@ use std::sync::mpsc::{self, Receiver};
 use sctk::reexports::calloop::channel::{self, Sender};
 use sctk::reexports::client::backend::Backend;
 use sctk::reexports::client::Connection;
-use state::SelectionTarget;
-use text::Text;
 
 pub mod mime;
 mod state;
@@ -21,6 +19,8 @@ mod text;
 mod worker;
 
 use mime::{AllowedMimeTypes, AsMimeTypes, MimeType};
+use state::SelectionTarget;
+use text::Text;
 
 /// Access to a Wayland clipboard.
 pub struct Clipboard {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,8 @@ impl Clipboard {
 
         if let Ok(reply) = self.request_receiver.recv() {
             match reply {
-                Ok((data, mime)) => T::try_from((data, mime)).map_err(std::io::Error::other),
+                Ok((data, mime)) => T::try_from((data, mime))
+                    .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err)),
                 Err(err) => Err(err),
             }
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,24 +81,38 @@ impl Clipboard {
         self.load_primary::<Text>().map(|t| t.0)
     }
 
-    /// Load raw clipboard data.
+    /// Load clipboard data for sepecific mime types.
     ///
     /// Loads content from a  primary clipboard on a last observed seat.
-    pub fn load_raw(
+    pub fn load_mime<D: TryFrom<(Vec<u8>, MimeType)>>(
         &self,
         allowed: impl Into<Cow<'static, [MimeType]>>,
-    ) -> Result<(Vec<u8>, MimeType)> {
-        self.load_inner(SelectionTarget::Clipboard, allowed)
+    ) -> Result<D> {
+        self.load_inner(SelectionTarget::Clipboard, allowed).and_then(|d| {
+            D::try_from(d).map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "Failed to load data of the requested type.",
+                )
+            })
+        })
     }
 
-    /// Load raw primary clipboard data.
+    /// Load primary clipboard data for specific mime types.
     ///
     /// Loads content from a  primary clipboard on a last observed seat.
-    pub fn load_primary_raw(
+    pub fn load_primary_mime<D: TryFrom<(Vec<u8>, MimeType)>>(
         &self,
         allowed: impl Into<Cow<'static, [MimeType]>>,
-    ) -> Result<(Vec<u8>, MimeType)> {
-        self.load_inner(SelectionTarget::Primary, allowed)
+    ) -> Result<D> {
+        self.load_inner(SelectionTarget::Primary, allowed).and_then(|d| {
+            D::try_from(d).map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "Failed to load data of the requested type.",
+                )
+            })
+        })
     }
 
     /// Store custom data to a clipboard.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,12 +58,8 @@ impl Clipboard {
 
         if let Ok(reply) = self.request_receiver.recv() {
             match reply {
-                Ok((data, mime)) => {
-                    T::try_from((data, mime)).map_err(|err| std::io::Error::other(err))
-                },
-                Err(err) => {
-                    return Err(err);
-                },
+                Ok((data, mime)) => T::try_from((data, mime)).map_err(std::io::Error::other),
+                Err(err) => Err(err),
             }
         } else {
             // The clipboard thread is dead, however we shouldn't crash downstream, so

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ use std::ffi::c_void;
 use std::io::Result;
 use std::sync::mpsc::{self, Receiver};
 
-use mime::{AllowedMimeTypes, AsMimeTypes, MimeType};
 use sctk::reexports::calloop::channel::{self, Sender};
 use sctk::reexports::client::backend::Backend;
 use sctk::reexports::client::Connection;
@@ -19,6 +18,8 @@ pub mod mime;
 mod state;
 mod text;
 mod worker;
+
+use mime::{AllowedMimeTypes, AsMimeTypes, MimeType};
 
 /// Access to a Wayland clipboard.
 pub struct Clipboard {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,18 +8,22 @@ use std::ffi::c_void;
 use std::io::Result;
 use std::sync::mpsc::{self, Receiver};
 
+use mime::{AllowedMimeTypes, AsMimeTypes, MimeType};
 use sctk::reexports::calloop::channel::{self, Sender};
 use sctk::reexports::client::backend::Backend;
 use sctk::reexports::client::Connection;
+use state::SelectionTarget;
+use text::Text;
 
-mod mime;
+pub mod mime;
 mod state;
+mod text;
 mod worker;
 
 /// Access to a Wayland clipboard.
 pub struct Clipboard {
     request_sender: Sender<worker::Command>,
-    request_receiver: Receiver<Result<String>>,
+    request_receiver: Receiver<Result<(Vec<u8>, MimeType)>>,
     clipboard_thread: Option<std::thread::JoinHandle<()>>,
 }
 
@@ -46,14 +50,21 @@ impl Clipboard {
         Self { request_receiver, request_sender, clipboard_thread }
     }
 
-    /// Load clipboard data.
-    ///
-    /// Loads content from a clipboard on a last observed seat.
-    pub fn load(&self) -> Result<String> {
-        let _ = self.request_sender.send(worker::Command::Load);
+    fn load_inner<T: AllowedMimeTypes + 'static>(&self, target: SelectionTarget) -> Result<T>
+    where
+        <T as TryFrom<(Vec<u8>, MimeType)>>::Error: std::error::Error + Send + Sync,
+    {
+        let _ = self.request_sender.send(worker::Command::Load(T::allowed().to_vec(), target));
 
         if let Ok(reply) = self.request_receiver.recv() {
-            reply
+            match reply {
+                Ok((data, mime)) => {
+                    T::try_from((data, mime)).map_err(|err| std::io::Error::other(err))
+                },
+                Err(err) => {
+                    return Err(err);
+                },
+            }
         } else {
             // The clipboard thread is dead, however we shouldn't crash downstream, so
             // propogating an error.
@@ -61,35 +72,73 @@ impl Clipboard {
         }
     }
 
-    /// Store to a clipboard.
+    /// Load custom clipboard data.
     ///
-    /// Stores to a clipboard on a last observed seat.
-    pub fn store<T: Into<String>>(&self, text: T) {
-        let request = worker::Command::Store(text.into());
-        let _ = self.request_sender.send(request);
+    /// Load the requested type from a clipboard on the last observed seat.
+    pub fn load<T: AllowedMimeTypes + 'static>(&self) -> Result<T>
+    where
+        <T as TryFrom<(Vec<u8>, MimeType)>>::Error: std::error::Error + Send + Sync,
+    {
+        self.load_inner(SelectionTarget::Clipboard)
+    }
+
+    /// Load clipboard data.
+    ///
+    /// Loads content from a clipboard on a last observed seat.
+    pub fn load_text(&self) -> Result<String> {
+        self.load::<Text>().map(|t| t.0)
+    }
+
+    /// Load custom primary clipboard data.
+    ///
+    /// Load the requested type from a primary clipboard on the last observed
+    /// seat.
+    pub fn load_primary<T: AllowedMimeTypes + 'static>(&self) -> Result<T>
+    where
+        <T as TryFrom<(Vec<u8>, MimeType)>>::Error: std::error::Error + Send + Sync,
+    {
+        self.load_inner(SelectionTarget::Primary)
     }
 
     /// Load primary clipboard data.
     ///
     /// Loads content from a  primary clipboard on a last observed seat.
-    pub fn load_primary(&self) -> Result<String> {
-        let _ = self.request_sender.send(worker::Command::LoadPrimary);
+    pub fn load_primary_text(&self) -> Result<String> {
+        self.load_primary::<Text>().map(|t| t.0)
+    }
 
-        if let Ok(reply) = self.request_receiver.recv() {
-            reply
-        } else {
-            // The clipboard thread is dead, however we shouldn't crash downstream, so
-            // propogating an error.
-            Err(std::io::Error::new(std::io::ErrorKind::Other, "clipboard is dead."))
-        }
+    fn store_inner<T: AsMimeTypes + Send + 'static>(&self, data: T, target: SelectionTarget) {
+        let request = worker::Command::Store(Box::new(data), target);
+        let _ = self.request_sender.send(request);
+    }
+
+    /// Store custom data to a clipboard.
+    ///
+    /// Stores data of the provided type to a clipboard on a last observed seat.
+    pub fn store<T: AsMimeTypes + Send + 'static>(&self, data: T) {
+        self.store_inner(data, SelectionTarget::Clipboard);
+    }
+
+    /// Store to a clipboard.
+    ///
+    /// Stores to a clipboard on a last observed seat.
+    pub fn store_text<T: Into<String>>(&self, text: T) {
+        self.store(Text(text.into()));
+    }
+
+    /// Store custom data to a primary clipboard.
+    ///
+    /// Stores data of the provided type to a primary clipboard on a last
+    /// observed seat.
+    pub fn store_primary<T: AsMimeTypes + Send + 'static>(&self, data: T) {
+        self.store_inner(data, SelectionTarget::Primary);
     }
 
     /// Store to a primary clipboard.
     ///
     /// Stores to a primary clipboard on a last observed seat.
-    pub fn store_primary<T: Into<String>>(&self, text: T) {
-        let request = worker::Command::StorePrimary(text.into());
-        let _ = self.request_sender.send(request);
+    pub fn store_primary_text<T: Into<String>>(&self, text: T) {
+        self.store_primary(Text(text.into()));
     }
 }
 

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -1,15 +1,20 @@
 use std::borrow::Cow;
-use thiserror::Error;
+use std::{error, fmt};
 
 /// List of allowed mimes.
 pub static ALLOWED_TEXT_MIME_TYPES: [&str; 3] =
     ["text/plain;charset=utf-8", "UTF8_STRING", "text/plain"];
 
-#[derive(Error, Debug)]
-pub enum Error {
-    #[error("Unsupported mime type")]
-    Unsupported,
+#[derive(Debug, Clone, Copy)]
+pub struct Error;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Unsupported mime type")
+    }
 }
+
+impl error::Error for Error {}
 
 /// Mime type supported by clipboard.
 #[derive(Clone, Eq, PartialEq, Debug, Default)]

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -49,6 +49,22 @@ impl Default for MimeType {
     }
 }
 
+impl From<Cow<'static, str>> for MimeType {
+    fn from(value: Cow<'static, str>) -> Self {
+        if let Some(pos) = ALLOWED_TEXT_MIME_TYPES.into_iter().position(|allowed| allowed == value)
+        {
+            MimeType::Text(match pos {
+                0 => Text::TextPlainUtf8,
+                1 => Text::Utf8String,
+                2 => Text::TextPlain,
+                _ => unreachable!(),
+            })
+        } else {
+            MimeType::Other(value)
+        }
+    }
+}
+
 impl AsRef<str> for MimeType {
     fn as_ref(&self) -> &str {
         match self {
@@ -119,4 +135,27 @@ impl std::fmt::Display for MimeType {
 /// expect is LF.
 pub fn normalize_to_lf(text: String) -> String {
     text.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use crate::mime::{MimeType, ALLOWED_TEXT_MIME_TYPES};
+
+    #[test]
+    fn test_from_str() {
+        assert_eq!(
+            MimeType::from(Cow::Borrowed(ALLOWED_TEXT_MIME_TYPES[0])),
+            MimeType::Text(crate::mime::Text::TextPlainUtf8)
+        );
+        assert_eq!(
+            MimeType::from(Cow::Borrowed(ALLOWED_TEXT_MIME_TYPES[1])),
+            MimeType::Text(crate::mime::Text::Utf8String)
+        );
+        assert_eq!(
+            MimeType::from(Cow::Borrowed(ALLOWED_TEXT_MIME_TYPES[2])),
+            MimeType::Text(crate::mime::Text::TextPlain)
+        );
+    }
 }

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -70,6 +70,9 @@ impl MimeType {
 /// Describes the mime types which are accepted.
 pub trait AllowedMimeTypes: TryFrom<(Vec<u8>, MimeType)> {
     /// List allowed mime types for the type to convert from a byte slice.
+    ///
+    /// Allowed mime types should be listed in order of decreasing preference,
+    /// most preferred first.
     fn allowed() -> Cow<'static, [MimeType]>;
 }
 

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -67,13 +67,13 @@ impl MimeType {
     }
 }
 
-/// Describes the mime types which are accepted
+/// Describes the mime types which are accepted.
 pub trait AllowedMimeTypes: TryFrom<(Vec<u8>, MimeType)> {
     /// List allowed mime types for the type to convert from a byte slice.
     fn allowed() -> Cow<'static, [MimeType]>;
 }
 
-/// Can be converted to data with the available mime types
+/// Can be converted to data with the available mime types.
 pub trait AsMimeTypes {
     /// List available mime types for this data to convert to a byte slice.
     fn available(&self) -> Cow<'static, [MimeType]>;

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -19,16 +19,16 @@ pub enum MimeType {
     /// text/plain;charset=utf-8 mime type.
     ///
     /// The primary mime type used by most clients
-    TextPlainUtf8 = 0,
+    TextPlainUtf8,
     /// UTF8_STRING mime type.
     ///
     /// Some X11 clients are using only this mime type, so we
     /// should have it as a fallback just in case.
-    Utf8String = 1,
+    Utf8String,
     /// text/plain mime type.
     ///
     /// Fallback without charset parameter.
-    TextPlain = 2,
+    TextPlain,
     /// Other mime type
     Other(Cow<'static, str>),
 }

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -86,12 +86,15 @@ pub trait AsMimeTypes {
 }
 
 impl MimeType {
-    /// Find first allowed mime type among the `offered_mime_types`.
+    /// Find first offered mime type among the `allowed_mime_types`.
     ///
     /// `find_allowed()` searches for mime type clipboard supports, if we have a
     /// match, returns `Some(MimeType)`, otherwise `None`.
-    pub fn find_allowed(offered_mime_types: &[String], allowed: &[Self]) -> Option<Self> {
-        allowed
+    pub fn find_allowed(
+        offered_mime_types: &[String],
+        allowed_mime_types: &[Self],
+    ) -> Option<Self> {
+        allowed_mime_types
             .iter()
             .find(|allowed| {
                 offered_mime_types.iter().any(|offered| offered.as_str() == allowed.as_ref())

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -69,16 +69,7 @@ impl AsRef<str> for MimeType {
     fn as_ref(&self) -> &str {
         match self {
             MimeType::Other(s) => s.as_ref(),
-            m => ALLOWED_TEXT_MIME_TYPES[m.discriminant()],
-        }
-    }
-}
-
-impl MimeType {
-    fn discriminant(&self) -> usize {
-        match self {
-            MimeType::Text(t) => *t as usize,
-            MimeType::Other(_) => 3,
+            MimeType::Text(text) => ALLOWED_TEXT_MIME_TYPES[*text as usize],
         }
     }
 }
@@ -123,7 +114,7 @@ impl std::fmt::Display for MimeType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             MimeType::Other(m) => write!(f, "{}", m),
-            m => write!(f, "{}", ALLOWED_TEXT_MIME_TYPES[m.discriminant()]),
+            MimeType::Text(text) => write!(f, "{}", ALLOWED_TEXT_MIME_TYPES[*text as usize]),
         }
     }
 }

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -37,7 +37,7 @@ impl AsRef<str> for MimeType {
     fn as_ref(&self) -> &str {
         match self {
             MimeType::Other(s) => s.as_ref(),
-            m => &ALLOWED_TEXT_MIME_TYPES[m.discriminant() as usize],
+            m => ALLOWED_TEXT_MIME_TYPES[m.discriminant() as usize],
         }
     }
 }
@@ -56,7 +56,7 @@ pub trait AllowedMimeTypes: TryFrom<(Vec<u8>, MimeType)> {
 /// Can be converted to data with the available mime types
 pub trait AsMimeTypes {
     /// Available mime types for this data
-    fn available<'a>(&'a self) -> Cow<'static, [MimeType]>;
+    fn available(&self) -> Cow<'static, [MimeType]>;
 
     /// Data as a specific mime_type
     fn as_bytes(&self, mime_type: &MimeType) -> Option<Cow<'static, [u8]>>;

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -97,7 +97,7 @@ impl MimeType {
     ///
     /// `find_allowed()` searches for mime type clipboard supports, if we have a
     /// match, returns `Some(MimeType)`, otherwise `None`.
-    pub fn find_allowed(
+    pub(crate) fn find_allowed(
         offered_mime_types: &[String],
         allowed_mime_types: &[Self],
     ) -> Option<Self> {

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -34,7 +34,7 @@ pub enum MimeType {
     ///
     /// Fallback without charset parameter.
     TextPlain,
-    /// Other mime type
+    /// Other mime type.
     Other(Cow<'static, str>),
 }
 
@@ -55,15 +55,16 @@ impl MimeType {
 
 /// Describes the mime types which are accepted
 pub trait AllowedMimeTypes: TryFrom<(Vec<u8>, MimeType)> {
+    /// List allowed mime types for the type to convert from a byte slice.
     fn allowed() -> Cow<'static, [MimeType]>;
 }
 
 /// Can be converted to data with the available mime types
 pub trait AsMimeTypes {
-    /// Available mime types for this data
+    /// List available mime types for this data to convert to a byte slice.
     fn available(&self) -> Cow<'static, [MimeType]>;
 
-    /// Data as a specific mime_type
+    /// Converts a type to a byte slice for the given mime type if possible.
     fn as_bytes(&self, mime_type: &MimeType) -> Option<Cow<'static, [u8]>>;
 }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -35,7 +35,7 @@ impl AsMimeTypes for Text {
         Self::allowed()
     }
 
-    fn as_bytes<'a>(&'a self, mime_type: &MimeType) -> Option<Cow<'static, [u8]>> {
+    fn as_bytes(&self, mime_type: &MimeType) -> Option<Cow<'static, [u8]>> {
         match mime_type {
             MimeType::TextPlainUtf8 | MimeType::Utf8String | MimeType::TextPlain => {
                 Some(Cow::Owned(self.0.as_bytes().to_owned()))

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,0 +1,46 @@
+use std::borrow::Cow;
+
+use crate::mime::{normalize_to_lf, AllowedMimeTypes, AsMimeTypes, Error, MimeType};
+
+pub struct Text(pub String);
+
+impl TryFrom<(Vec<u8>, MimeType)> for Text {
+    type Error = Error;
+
+    fn try_from((content, mime_type): (Vec<u8>, MimeType)) -> Result<Self, Self::Error> {
+        let utf8 = String::from_utf8_lossy(&content);
+        let content = match utf8 {
+            Cow::Borrowed(_) => String::from_utf8(content).unwrap(),
+            Cow::Owned(content) => content,
+        };
+
+        // Post-process the content according to mime type.
+        let content = match mime_type {
+            MimeType::TextPlainUtf8 | MimeType::TextPlain => normalize_to_lf(content),
+            MimeType::Utf8String => content,
+            MimeType::Other(_) => return Err(Error::Unsupported),
+        };
+        Ok(Text(content))
+    }
+}
+
+impl AllowedMimeTypes for Text {
+    fn allowed() -> Cow<'static, [MimeType]> {
+        Cow::Borrowed(&[MimeType::TextPlainUtf8, MimeType::Utf8String, MimeType::TextPlain])
+    }
+}
+
+impl AsMimeTypes for Text {
+    fn available(&self) -> Cow<'static, [MimeType]> {
+        Self::allowed()
+    }
+
+    fn as_bytes<'a>(&'a self, mime_type: &MimeType) -> Option<Cow<'static, [u8]>> {
+        match mime_type {
+            MimeType::TextPlainUtf8 | MimeType::Utf8String | MimeType::TextPlain => {
+                Some(Cow::Owned(self.0.as_bytes().to_owned()))
+            },
+            MimeType::Other(_) => None,
+        }
+    }
+}

--- a/src/text.rs
+++ b/src/text.rs
@@ -18,7 +18,7 @@ impl TryFrom<(Vec<u8>, MimeType)> for Text {
         let content = match mime_type {
             MimeType::TextPlainUtf8 | MimeType::TextPlain => normalize_to_lf(content),
             MimeType::Utf8String => content,
-            MimeType::Other(_) => return Err(Error::Unsupported),
+            MimeType::Other(_) => return Err(Error),
         };
         Ok(Text(content))
     }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -64,10 +64,21 @@ fn worker_impl(
                     Command::Store(data, target) => {
                         state.store_selection(target, data);
                     },
-                    Command::Load(mime_types, target)
+                    Command::Load(mime_types, SelectionTarget::Clipboard)
                         if state.data_device_manager_state.is_some() =>
                     {
-                        if let Err(err) = state.load_selection(target, &mime_types) {
+                        if let Err(err) =
+                            state.load_selection(SelectionTarget::Clipboard, &mime_types)
+                        {
+                            let _ = state.reply_tx.send(Err(err));
+                        }
+                    },
+                    Command::Load(mime_types, SelectionTarget::Primary)
+                        if state.primary_selection_manager_state.is_some() =>
+                    {
+                        if let Err(err) =
+                            state.load_selection(SelectionTarget::Primary, &mime_types)
+                        {
                             let _ = state.reply_tx.send(Err(err));
                         }
                     },

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -28,10 +28,10 @@ pub fn spawn(
 
 /// Clipboard worker thread command.
 pub enum Command {
-    /// Loads data for the first available mime type in the provided list
+    /// Loads data for the first available mime type in the provided list.
     Load(Vec<MimeType>, SelectionTarget),
+    /// Store Data with the given mime types.
     Store(Box<dyn AsMimeTypes + Send>, SelectionTarget),
-    /// Store Data with the given Mime Types
     /// Shutdown the worker.
     Exit,
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::io::{Error, ErrorKind, Result};
 use std::sync::mpsc::Sender;
 
@@ -29,7 +30,7 @@ pub fn spawn(
 /// Clipboard worker thread command.
 pub enum Command {
     /// Loads data for the first available mime type in the provided list.
-    Load(Vec<MimeType>, SelectionTarget),
+    Load(Cow<'static, [MimeType]>, SelectionTarget),
     /// Store Data with the given mime types.
     Store(Box<dyn AsMimeTypes + Send>, SelectionTarget),
     /// Shutdown the worker.


### PR DESCRIPTION
This adds support for loading and storing data that is not text. I've renamed some of the existing methods, so it's a breaking change, but I guess I could avoid renaming the methods so that isn't an issue. and make the methods for loading and storing custom types something like `store_custom` or `load_custom`.