### PR TITLE
ci: enable running for master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [master]
 
 env:
   RUST_BACKTRACE: 1


### PR DESCRIPTION
While this repo doesn't allow direct pushes, thus the impact of it was effectively zero, we should still run it for pushes on master.